### PR TITLE
Use drupal/core-recommeded library as suggested by Migrating Composer…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 sudo: false
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
@@ -29,7 +28,7 @@ install:
 
 script:
   - if [[ $RELEASE = dev ]]; then composer --verbose remove --no-update drupal/console; fi;
-  - if [[ $RELEASE = dev ]]; then composer --verbose require --no-update drupal/core:8.8.x-dev; composer --verbose require --no-update --dev drupal/core-dev:8.8.x-dev; fi;
+  - if [[ $RELEASE = dev ]]; then composer --verbose require --no-update drupal/core-recommended:8.8.x-dev; composer --verbose require --no-update --dev drupal/core-dev:8.8.x-dev; fi;
   - if [[ $RELEASE = dev ]]; then composer --verbose update; fi;
   - ./vendor/bin/drush site-install --verbose --yes --db-url=sqlite://tmp/site.sqlite
   - ./vendor/bin/drush runserver $SIMPLETEST_BASE_URL &

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ new release of Drupal core.
 
 Follow the steps below to update your core files.
 
-1. Run `composer update drupal/core drupal/core-dev --with-dependencies` to update Drupal Core and its dependencies.
+1. Run `composer update drupal/core-recommended drupal/core-dev --with-dependencies` to update Drupal Core and its dependencies.
 2. Run `git diff` to determine if any of the scaffolding files have changed.
    Review the files for any changes and restore any customizations to
   `.htaccess` or `robots.txt`.

--- a/composer.json
+++ b/composer.json
@@ -139,7 +139,7 @@
     "cweagans/composer-patches": "^1.6.5",
     "dimsemenov/magnific-popup": "master",
     "drupal/console": "^1.0.2",
-    "drupal/core": "^8.8.0",
+    "drupal/core-recommended": "^8.8.0",
     "drupal/core-composer-scaffold": "^8.8.0",
     "drush/drush": "^9.7.1 | ^10.0.0",
     "recurser/jquery-simple-color": "master",


### PR DESCRIPTION
https://www.drupal.org/docs/develop/using-composer/using-drupals-composer-scaffold#s-migrating-composer-scaffold doc says use `drupal/core-recommened` to replace `drupal/core

Also, `drupal/search_api_solr` requires at least PHP7.1, so I removed 7.0 from .travis, we probably should remove 7.1 as well, as it is EOF, too. 