### PR TITLE
D9 Transition Cleanup

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -2,13 +2,14 @@ name: orange
 recipe: drupal9
 config:
   php: 7.3
-
   via: nginx
   webroot: web
 
 proxy:
   mailhog:
     - mail.orange.lndo.site
+  search:
+    - solr.orange.lndo.site:8983
 
 services:
   appserver:
@@ -16,14 +17,20 @@ services:
       - composer install
 
   search:
-    type: solr
+    type: solr:8
+    core: orange
     portforward: true
+    # Export the site solr config and commit to the project.
+    # Can be exported from: /admin/config/search/search-api/server/solr/solr_configset/config-zip
+    # Uncomment and set the path to the exported config below.
+    #config:
+      #dir: solr_conf
 
   node:
     type: node
-    #build:
-      # Compile custom theme styles.
-      #- cd /app/web/themes/custom/your_custom_theme && npm install && gulp -- sass
+    build:
+      # Compile theme styles.
+      - cd /app/web/themes/contrib/orange_starter && npm install && gulp -- sass
     globals:
       gulp-cli: latest
 

--- a/README.md
+++ b/README.md
@@ -37,19 +37,19 @@ all files not excluded by the .gitignore file.
 > Some documentation to help you get started.
 
 Starting a Drupal build with Drupal Commerce?
-* [Orange E-Commerce Profile](https://github.com/AcroMedia/orange_ecom_profile/blob/8.x-1.x/README.md)
-* [Orange E-Commerce Starter Theme](https://github.com/AcroMedia/orange_ecom_starter/blob/8.x-1.x/README.md)
+* [Orange E-Commerce Profile](https://www.drupal.org/project/orange_ecom_profile)
+* [Orange E-Commerce Starter Theme](https://www.drupal.org/project/orange_ecom_starter)
 
 Starting a Drupal build that doesn't need Drupal Commerce?
-* [Orange Profile](https://github.com/AcroMedia/orange_profile/blob/8.x-1.x/README.md)
-* [Orange Starter Theme](https://github.com/AcroMedia/orange_starter/blob/8.x-1.x/README.md)
+* [Orange Profile](https://www.drupal.org/project/orange_profile)
+* [Orange Starter Theme](https://www.drupal.org/project/orange_starter)
 
 ## Applied Patches
 
 * Drupal Core
   * [Issue](https://www.drupal.org/project/drupal/issues/2771837) | [Patch](https://www.drupal.org/files/issues/2018-09-13/drupalimage_ckeditor-2771837-34.patch) - Problem with CKEditor not maintain data-entity attributes.
-* CKEditor Font Size and Family
-  * [Issue](https://www.drupal.org/project/ckeditor_font/issues/2729087) | [Patch](https://www.drupal.org/files/issues/2018-09-27/2729087_ckeditor_font_file_path.patch) - Path to plugin is incorrect unless base path is /.
+* Color Field
+  * [Issue](https://www.drupal.org/project/color_field/issues/3002836) | [Patch](https://www.drupal.org/files/issues/2018-11-07/no_functionality_of_almost_all_widgets-3002836-7.patch) - No functionality of the Spectrum widget on Drupal 8.6.x with latest stable or dev.
 * Commerce Google Tag Manager
   * [Issue](https://www.drupal.org/project/commerce_google_tag_manager/issues/3066949) | [Patch](https://www.drupal.org/files/issues/2020-03-27/use-product-variation-sku-if-available-3066949-7-alpha3.patch) - Use product variation SKU if available instead of product ID.
 

--- a/web/sites/default/development.services.local.yml
+++ b/web/sites/default/development.services.local.yml
@@ -1,0 +1,11 @@
+# Local development services.
+#
+# To activate this feature, follow the instructions at the top of the
+# 'example.settings.local.php' file, which sits next to this file.
+parameters:
+  http.response.debug_cacheability_headers: true
+  twig.config:
+    debug: true
+services:
+  cache.backend.null:
+    class: Drupal\Core\Cache\NullBackendFactory

--- a/web/sites/default/development.settings.local.php
+++ b/web/sites/default/development.settings.local.php
@@ -18,14 +18,21 @@
  * Database configuration.
  */
 $databases['default']['default'] = [
-  'database' => 'drupal8',
-  'username' => 'drupal8',
-  'password' => 'drupal8',
+  'database' => 'drupal9',
+  'username' => 'drupal9',
+  'password' => 'drupal9',
   'host' => 'database',
   'port' => '',
   'driver' => 'mysql',
   'prefix' => '',
 ];
+
+/**
+ * Swiftmailer.
+ */
+$config['swiftmailer.transport']['transport'] = 'smtp';
+$config['swiftmailer.transport']['smtp_host'] = 'mailhog';
+$config['swiftmailer.transport']['smtp_port'] = '1025';
 
 /**
  * File system.
@@ -42,7 +49,7 @@ $config['system.logging']['error_level'] = 'verbose';
 /**
  * Enable local development services.
  */
-$settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
+$settings['container_yamls'][] = DRUPAL_ROOT . '/sites/default/development.services.local.yml';
 
 /**
  * Aggregation and caching.
@@ -58,6 +65,7 @@ $config['advagg.settings']['enabled'] = FALSE;
  */
 $config['search_api.server.solr']['backend_config']['connector_config']['host'] = 'search';
 $config['search_api.server.solr']['backend_config']['connector_config']['port'] = '8983';
+$config['search_api.server.solr']['backend_config']['connector_config']['core'] = 'orange';
 
 /**
  * Email rerouting.


### PR DESCRIPTION
A few improvements so starting a project goes smoothly and more detailed documentation notes.

- Update readme to point to drupal.org links and update applied patches.
- Update solr version and improve documentation.
- Add Orange Starter to compile on build so you get a working site when starting up a project.
- Add a local development services file so we can customize one without the default core one being overwritten on updates.
- Update the development local settings file to include proper defaults for Drupal 9 and to work with Lando's MailHog.