### PR TITLE
Add composer version config in Lando

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -4,6 +4,9 @@ config:
   php: 7.3
   via: nginx
   webroot: web
+  # Change Composer version with caution.
+  # v2.x can be incompatible with certain Drupal dependencies.
+  composer_version: '1.10.1'
 
 proxy:
   mailhog:


### PR DESCRIPTION
If you clone the project and try to `composer install`, it will fail due to `drupal/orange_profile` saying it requires 8x versions instead of the v9 variants. However, if you change Lando to use Composer 1x, there's no issues with Composer anymore. I suspect some related modules just don't play nice yet with Composer 2x.

Since the project is basically broken for anyone currently trying to use it as-is, I think this PR is the best way forward at the moment.